### PR TITLE
feat: add scheduled theme toggling

### DIFF
--- a/background.js
+++ b/background.js
@@ -1,37 +1,160 @@
-function toggleTheme() {
+function toggleTheme(input) {
+	const lightId = 'firefox-compact-light@mozilla.org';
+	const darkId = 'firefox-compact-dark@mozilla.org';
+
+	let desiredMode = null;
+
+	if (typeof input === 'string') {
+		if (input === 'light' || input === 'dark') desiredMode = input;
+	}
+
+	function toggleExtensions(arg) {
+		let enable = arg === 'light';
+		browser.management.setEnabled(lightId, enable);
+		browser.management.setEnabled(darkId, !enable);
+	}
+
 	browser.management.getAll().then(extensions => {
-		for (let extension of extensions) {
-			if (extension.id !== 'firefox-compact-light@mozilla.org') continue;
-			if (extension.enabled) {
-				browser.management.get("firefox-compact-dark@mozilla.org").then(info => {
-					browser.management.setEnabled("firefox-compact-dark@mozilla.org", !info.enabled);
-				})
-			} else {
-				browser.management.get("firefox-compact-light@mozilla.org").then(info => {
-					browser.management.setEnabled("firefox-compact-light@mozilla.org", !info.enabled);
-				});
-			};
-		};
+		const lightExt = extensions.find(e => e.id === lightId);
+		const darkExt = extensions.find(e => e.id === darkId);
+
+		if (!lightExt || !darkExt) {
+			return;
+		}
+
+		if (desiredMode === null) {
+			systemTheme(false);
+			applyCustomSchedule(false);
+			lightExt.enabled ? toggleExtensions('dark') : toggleExtensions('light');
+		} else {
+			toggleExtensions(desiredMode);
+		}
 	});
 }
 
-browser.action.onClicked.addListener(toggleTheme);
+browser.action.onClicked.addListener(() => toggleTheme(null));
 
-function toggleSystemTheme() {
-	browser.management.get("default-theme@mozilla.org").then(info => {
-		browser.management.setEnabled("default-theme@mozilla.org", !info.enabled);
+function toggleThemeSetting(input, menuId) {
+	let enableTheme;
+
+	enableTheme = typeof input === 'object' && input.menuItemId === menuId ? input.checked : Boolean(input);
+
+	if (menuId === 'use-systemTheme' && enableTheme) {
+		applyCustomSchedule(false);
+	} else if (menuId === 'use-customSchedule' && enableTheme) {
+		systemTheme(false);
+	}
+
+	browser.menus.update(menuId, { checked: enableTheme });
+
+	return enableTheme;
+}
+
+function systemTheme(input) {
+	const enableTheme = toggleThemeSetting(input, "use-systemTheme");
+
+	if (enableTheme) {
+		browser.management.get("default-theme@mozilla.org").then(info => {
+			if (!info.enabled) {
+				browser.management.setEnabled("default-theme@mozilla.org", true);
+			}
+		});
+	}
+}
+
+function applyCustomSchedule(input) {
+	const enabled = toggleThemeSetting(input, "use-customSchedule");
+	if (enabled) {
+		startSchedulePolling();
+	} else {
+		browser.alarms.clear("checkTheme");
+	}
+}
+
+let lastAppliedTheme = null;
+
+function startSchedulePolling() {
+	checkAndApplyTheme();
+	browser.alarms.clear("checkTheme");
+	lastAppliedTheme = null;
+	browser.alarms.create("checkTheme", { periodInMinutes: 1 });
+}
+
+function getMinutes(t) {
+	const [h, m] = t.split(":").map(Number);
+	return h * 60 + m;
+}
+
+function checkAndApplyTheme() {
+	const now = new Date();
+	const current = now.getHours() * 60 + now.getMinutes();
+
+	browser.storage.local.get("themeSchedule").then(result => {
+		const s = result.themeSchedule || { light: "06:00", dark: "18:00" };
+		const light = getMinutes(s.light);
+		const dark = getMinutes(s.dark);
+
+		const newTheme =
+			light < dark
+				? current >= light && current < dark ? "light" : "dark"
+				: current >= light || current < dark ? "light" : "dark";
+
+		if (newTheme !== lastAppliedTheme) {
+			lastAppliedTheme = newTheme;
+			toggleTheme(newTheme);
+		}
 	});
 }
 
-browser.menus.create({
-	id: "use-systemtheme",
-	type: "normal",
-	title: "Use system theme (auto)",
-	contexts: ["action"],
-	icons: {
-		"16": "icons/browser.svg",
-		"32": "icons/browser.svg"
-	},
+browser.alarms.onAlarm.addListener(alarm => {
+	if (alarm.name === "checkTheme") {
+		checkAndApplyTheme();
+	}
 });
 
-browser.menus.onClicked.addListener(toggleSystemTheme);
+browser.menus.onClicked.addListener((info, tab) => {
+	switch (info.menuItemId) {
+		case "use-systemTheme":
+			systemTheme(info);
+			break;
+		case "use-customSchedule":
+			applyCustomSchedule(info);
+			break;
+		case "customizeTheme":
+			browser.tabs.create({
+				url: browser.runtime.getURL("settings.html")
+			});
+			break;
+		default:
+			console.warn("Unhandled menu item:", info.menuItemId);
+	}
+});
+
+browser.runtime.onInstalled.addListener(() => {
+	browser.menus.create({
+		id: "use-systemTheme",
+		type: "checkbox",
+		title: "Use system theme (auto)",
+		contexts: ["action"],
+		checked: false
+	});
+
+	browser.menus.create({
+		id: "use-customSchedule",
+		type: "checkbox",
+		title: "Use scheduled theme (custom)",
+		contexts: ["action"],
+		checked: false
+	});
+
+	browser.menus.create({
+		id: "customizeTheme",
+		type: "normal",
+		title: "Customize theme schedule",
+		contexts: ["action"],
+		icons: {
+			"16": "icons/browser.svg",
+			"32": "icons/browser.svg"
+		}
+	});
+});

--- a/manifest.json
+++ b/manifest.json
@@ -31,13 +31,19 @@
       "suggested_key": {
         "default": "Ctrl+Shift+0"
       },
-    "description": "Toggle browser theme"
+      "description": "Toggle browser theme"
     }
   },
   "permissions": [
     "management",
-    "menus"
+    "storage",
+    "menus",
+    "alarms"
   ],
+  "options_ui": {
+    "page": "settings.html",
+    "open_in_tab": true
+  },
   "background": {
     "scripts": [
       "background.js"

--- a/settings.html
+++ b/settings.html
@@ -1,0 +1,177 @@
+<!DOCTYPE html>
+<html lang="en">
+
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Settings</title>
+  <style>
+    * {
+      margin: 0;
+      padding: 0;
+      box-sizing: border-box;
+      font-family: 'Segoe UI', Tahoma, Geneva, Verdana, sans-serif;
+    }
+
+    body {
+      background-color: #e2e2e2;
+      display: flex;
+      justify-content: center;
+      align-items: center;
+      min-height: 100vh;
+      padding: 20px;
+    }
+
+    .settings-container {
+      background: white;
+      border-radius: 12px;
+      padding: 2rem;
+      width: 100%;
+      max-width: 600px;
+      box-shadow: 0 4px 12px rgba(0, 0, 0, 0.1);
+    }
+
+    h1 {
+      text-align: center;
+      color: #333;
+      margin-bottom: 2rem;
+      font-size: 2rem;
+    }
+
+    .settings-section {
+      margin-bottom: 2rem;
+    }
+
+    h2 {
+      color: #444;
+      font-size: 1.4rem;
+      margin-bottom: 1rem;
+      border-bottom: 1px solid #eee;
+      padding-bottom: 0.5rem;
+    }
+
+    .form-group {
+      margin-bottom: 1rem;
+      display: flex;
+      align-items: center;
+      gap: 1rem;
+    }
+
+    label {
+      color: #555;
+      font-weight: 500;
+      font-size: 1rem;
+      flex: 1;
+    }
+
+    input[type="time"],
+    select {
+      padding: 0.5rem;
+      border: 1px solid #ddd;
+      border-radius: 6px;
+      font-size: 1rem;
+      transition: border-color 0.3s ease;
+    }
+
+    input[type="time"]:focus,
+    select:focus {
+      outline: none;
+      border-color: #007bff;
+      box-shadow: 0 0 0 2px rgba(0, 123, 255, 0.1);
+    }
+
+    select {
+      flex: 2;
+    }
+
+    button#saveBtn {
+      display: block;
+      width: 100%;
+      padding: 0.75rem;
+      background-color: #007bff;
+      color: white;
+      border: none;
+      border-radius: 8px;
+      font-size: 1rem;
+      font-weight: 500;
+      cursor: pointer;
+      transition: background-color 0.3s ease;
+    }
+
+    button#saveBtn:hover {
+      background-color: #0056b3;
+    }
+
+    #saveMsg,
+    #errorMsg {
+      text-align: center;
+      margin-top: 1rem;
+      font-weight: 500;
+      display: none;
+    }
+
+    #saveMsg.success {
+      display: block;
+      color: #28a745;
+    }
+
+    #saveMsg.fail {
+      display: block;
+      color: #dc3545;
+    }
+
+    #errorMsg {
+      color: #dc3545;
+    }
+
+    @media (max-width: 480px) {
+      .settings-container {
+        padding: 1.5rem;
+      }
+
+      h1 {
+        font-size: 1.6rem;
+      }
+
+      h2 {
+        font-size: 1.2rem;
+      }
+
+      .form-group {
+        flex-direction: column;
+        align-items: flex-start;
+      }
+    }
+  </style>
+</head>
+
+<body>
+  <div class="settings-container">
+    <h1>Settings</h1>
+
+    <!-- Theme Schedule Section -->
+    <div class="settings-section">
+      <h2>Theme Schedule</h2>
+      <div class="form-group">
+        <label for="lightTime">🌞 Light Theme Start</label>
+        <input type="time" id="lightTime" />
+      </div>
+      <div class="form-group">
+        <label for="darkTime">🌙 Dark Theme Start</label>
+        <input type="time" id="darkTime" />
+      </div>
+    </div>
+
+    <!-- Save Button -->
+    <button id="saveBtn">💾 Save Settings</button>
+
+    <!-- Success and Error Messages -->
+    <div id="saveMsg"></div>
+    <div id="errorMsg"></div>
+  </div>
+
+  <!-- Link your external JS -->
+  <script src="settings.js"></script>
+</body>
+
+</html>

--- a/settings.js
+++ b/settings.js
@@ -1,0 +1,57 @@
+document.addEventListener("DOMContentLoaded", () => {
+  const lightInput = document.getElementById("lightTime");
+  const darkInput = document.getElementById("darkTime");
+  const saveBtn = document.getElementById("saveBtn");
+  const saveMsg = document.getElementById("saveMsg");
+  const errorMsg = document.getElementById("errorMsg");
+
+  // Load existing schedule
+  browser.storage.local.get("themeSchedule").then(result => {
+    const schedule = result.themeSchedule || {};
+    lightInput.value = schedule.light || "06:00";
+    darkInput.value = schedule.dark || "18:00";
+  });
+
+  // Save new schedule
+  saveBtn.addEventListener("click", () => {
+    const lightTime = lightInput.value;
+    const darkTime = darkInput.value;
+
+    // Clear previous messages
+    [errorMsg, saveMsg].forEach(el => {
+      el.textContent = "";
+      el.style.display = "none";
+    });
+    saveMsg.className = "";
+
+    if (!lightTime || !darkTime) {
+      errorMsg.textContent = "Please select both light and dark theme times.";
+      errorMsg.style.display = "block";
+      return;
+    }
+
+    if (lightTime === darkTime) {
+      errorMsg.textContent = "Light and dark times cannot be the same.";
+      errorMsg.style.display = "block";
+      return;
+    }
+
+    browser.storage.local.set({
+      themeSchedule: {
+        light: lightTime,
+        dark: darkTime
+      }
+    }).then(() => {
+      saveMsg.textContent = "Settings saved successfully!";
+      saveMsg.className = "success";
+      saveMsg.style.display = "block";
+      setTimeout(() => {
+        saveMsg.style.display = "none";
+      }, 2000);
+    }).catch(() => {
+      saveMsg.textContent = "Failed to save settings.";
+      saveMsg.className = "fail";
+      saveMsg.style.display = "block";
+    });
+  });
+});


### PR DESCRIPTION
 Description:
 -------------
 This feature update adds support for a custom schedule to automatically switch between light and dark theme.

 Key Features:
 -------------
 - Manual toggle between Firefox Compact Light and Compact Dark themes (existing)
 - Option to use the system default Firefox theme (existing)
 - Custom schedule for automatic light/dark switching (new)
 - Context menu items with checkbox state persistence (new)
 --------------
![250605_19h19m16s_screenshot](https://github.com/user-attachments/assets/36f95da1-96a5-4c06-97a1-af5f56d24226)

 Menu Behavior:
 --------------
 1. Manual Toggle (Click on extension icon):
    - Immediately toggles between light and dark themes.
    - **Disables both**:
        - "Use system theme (auto)"
        - "Use scheduled theme (custom)"

 2. "Use system theme (auto)":
    - Enables Firefox’s default system theme.
    - **Disables** the "Use scheduled theme (custom)" option.

 3. "Use scheduled theme (custom)":
    - Automatically switches between light and dark themes based on time.
    - **Disables** the "Use system theme (auto)" option.

 4. "Customize theme schedule":
    - Opens `settings.html` to configure custom light/dark schedule.
    - Schedule stored in `themeSchedule` (default: light at 06:00, dark at 18:00).

 Theme Interaction Summary:
 --------------------------
 - Only one mode is active at a time: manual, system theme, or scheduled.
 - Activating one deactivates the others to avoid conflicts.
 - This ensures theme control stays predictable and deterministic.

